### PR TITLE
fix: typo in `tasks/main.yml` for `openssl_pip_packages`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   ansible.builtin.pip:
     name: "{{ openssl_pip_packages }}"
   when:
-    - openssl_pip_package | length > 0
+    - openssl_pip_packages | length > 0
 
 - name: Create key directory
   ansible.builtin.file:


### PR DESCRIPTION
fix: typo in `tasks/main.yml` for `openssl_pip_packages`

fix below error log : 
```bash
fatal: [debian]: FAILED! => {"msg": "The conditional check 'openssl_pip_package | length > 0' failed. The error was: error while evaluating conditional (openssl_pip_package | length > 0): 'openssl_pip_package' is undefined. 'openssl_pip_package' is undefined\n\nThe error appears to be in '/Users/kholisgumelar/.ansible/collections/ansible_collections/robertdebock/roles/roles/openssl/tasks/main.yml': line 14, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Install pip packages\n  ^ here\n"}
```
